### PR TITLE
feat: add preflight validation for sync actions (DS-003)

### DIFF
--- a/src/dirsync/__init__.py
+++ b/src/dirsync/__init__.py
@@ -1,0 +1,16 @@
+from .config import ConfigManager, SyncAction, SyncConfig
+from .constants import APP_NAME, CONFIG_DIR, CONFIG_PATH, SUPPORTED_ACTION_TYPES, SUPPORTED_METHODS
+from .validator import ConfigValidator, PreflightValidator
+
+__all__ = [
+    "ConfigManager",
+    "SyncAction",
+    "SyncConfig",
+    "ConfigValidator",
+    "PreflightValidator",
+    "APP_NAME",
+    "CONFIG_DIR",
+    "CONFIG_PATH",
+    "SUPPORTED_ACTION_TYPES",
+    "SUPPORTED_METHODS",
+]

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -95,7 +95,8 @@ class ConfigManager:
 
     def load(self) -> SyncConfig:
         with self.path.open("r", encoding="utf-8") as handle:
-            raw = yaml.safe_load(handle) or {}
+            raw = yaml.safe_load(handle)
+        raw = {} if raw is None else raw
         if not isinstance(raw, dict):
             raise ValueError("Configuration file must be a YAML mapping at the top level.")
         raw_actions = raw.get("actions", [])
@@ -106,7 +107,12 @@ class ConfigManager:
         for index, item in enumerate(raw_actions):
             if not isinstance(item, dict):
                 raise ValueError(f"Configuration action at index {index} must be a mapping.")
-            actions.append(SyncAction(**item).normalize())
+            try:
+                actions.append(SyncAction(**item).normalize())
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Configuration action at index {index} is invalid: {exc}"
+                ) from exc
         self.config = SyncConfig(sync_tool=raw.get("sync_tool", "rsync"), actions=actions)
         return self.config
 
@@ -162,7 +168,8 @@ class ConfigManager:
         partial state corruption on validation failure.
         """
         with source.open("r", encoding="utf-8") as handle:
-            payload = yaml.safe_load(handle) or {}  # Default to empty dict if file is empty
+            payload = yaml.safe_load(handle)
+        payload = {} if payload is None else payload
         if not isinstance(payload, dict):
             raise ValueError("Imported configuration must be a YAML mapping at the top level.")
         raw_actions = payload.get("actions", [])
@@ -175,7 +182,12 @@ class ConfigManager:
                 raise ValueError(
                     f"Imported configuration action at index {index} must be a mapping."
                 )
-            actions.append(SyncAction(**item).normalize())
+            try:
+                actions.append(SyncAction(**item).normalize())
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Imported configuration action at index {index} is invalid: {exc}"
+                ) from exc
 
         # Create temporary config for validation (don't mutate self.config yet)
         temp_config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -50,18 +50,16 @@ class SyncAction:
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(self)
-
         # Keep validate() aligned with normalize()-time constraints without
-        # mutating the current action instance.
+        # mutating the current action instance, then validate the normalized
+        # copy so warnings reflect the effective configuration.
         try:
-            deepcopy(self).normalize()
-        except ValueError as exc:
-            errors = [*errors, str(exc)]
-            is_valid = False
+            normalized = deepcopy(self).normalize()
+        except (ValueError, AttributeError, TypeError) as exc:
+            return False, [str(exc)], []
 
-        return is_valid, errors, warnings
+        validator = PreflightValidator()
+        return validator.validate_action(normalized)
 
 
 @dataclass

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -216,11 +216,22 @@ class ConfigManager:
             if docs.exists() and docs.is_dir():
                 default_src = docs
             else:
-                fallback_src.mkdir(parents=True, exist_ok=True)
+                if fallback_src.exists():
+                    if not fallback_src.is_dir():
+                        raise ValueError(
+                            f"Default source path '{fallback_src}' exists but is not a directory."
+                        )
+                else:
+                    fallback_src.mkdir(parents=True, exist_ok=True)
                 default_src = fallback_src
 
             dst_path = home / "dir-sync-backups"
-            if not dst_path.exists():
+            if dst_path.exists():
+                if not dst_path.is_dir():
+                    raise ValueError(
+                        f"Default destination path '{dst_path}' exists but is not a directory."
+                    )
+            else:
                 dst_path.mkdir(parents=True, exist_ok=True)
 
             sample = SyncAction(

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -109,8 +109,9 @@ class ConfigManager:
         if validate and not self.skip_validation:
             is_valid, errors, warnings = self.validate()
             if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
                 raise ValueError(
-                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                    "Configuration validation failed:\n" + error_lines
                 )
             # Log warnings but don't block save
             for warning in warnings:
@@ -128,8 +129,9 @@ class ConfigManager:
         if validate and not self.skip_validation:
             is_valid, errors, warnings = self.validate()
             if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
                 raise ValueError(
-                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                    "Configuration validation failed:\n" + error_lines
                 )
 
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -162,8 +164,9 @@ class ConfigManager:
             validator = ConfigValidator()
             is_valid, errors, warnings = validator.validate_config(temp_config.actions)
             if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
                 raise ValueError(
-                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                    "Configuration validation failed:\n" + error_lines
                 )
             # Log warnings but don't block import
             for warning in warnings:

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -11,6 +11,9 @@ import yaml
 from .constants import CONFIG_PATH, SUPPORTED_ACTION_TYPES, SUPPORTED_METHODS
 from .validator import ConfigValidator, PreflightValidator
 
+# Use module-level logger for consistent logging
+_logger = logging.getLogger(__name__)
+
 
 @dataclass
 class SyncAction:
@@ -111,7 +114,7 @@ class ConfigManager:
                 )
             # Log warnings but don't block save
             for warning in warnings:
-                logging.warning("Config warning: %s", warning)
+                _logger.warning("Config warning: %s", warning)
 
         data = {
             "sync_tool": self.config.sync_tool,
@@ -148,7 +151,7 @@ class ConfigManager:
         partial state corruption on validation failure.
         """
         with source.open("r", encoding="utf-8") as handle:
-            payload = yaml.safe_load(handle)
+            payload = yaml.safe_load(handle) or {}  # Default to empty dict if file is empty
         actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
         
         # Create temporary config for validation (don't mutate self.config yet)
@@ -173,11 +176,25 @@ class ConfigManager:
 
     def ensure_default(self) -> None:
         if not self.config.actions:
-            # Use a safe default that doesn't create recursive backups under home
+            # Try to find an existing directory for the default backup
+            # Use Documents if it exists, otherwise fall back to home
+            home = Path.home()
+            docs = home / "Documents"
+            if docs.exists() and docs.is_dir():
+                default_src = str(docs)
+            else:
+                # Fallback to home if Documents doesn't exist
+                default_src = str(home)
+            
+            # Destination is always under dir-sync-backups subfolder
+            dst_path = home / "dir-sync-backups"
+            if not dst_path.exists():
+                dst_path.mkdir(parents=True, exist_ok=True)
+            
             sample = SyncAction(
                 name="documents-backup",
-                src_path=str(Path.home() / "Documents"),
-                dst_path=str(Path.home() / "dir-sync-backups" / "documents"),
+                src_path=default_src,
+                dst_path=str(dst_path / "documents"),
                 method="one_way",
                 action_type="manual",
             )

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import yaml
 
 from .constants import CONFIG_PATH, SUPPORTED_ACTION_TYPES, SUPPORTED_METHODS
+from .validator import ConfigValidator, PreflightValidator
 
 
 @dataclass
@@ -37,6 +39,15 @@ class SyncAction:
         self.includes = [p.strip() for p in self.includes if p.strip()]
         self.excludes = [p.strip() for p in self.excludes if p.strip()]
         return self
+
+    def validate(self) -> Tuple[bool, List[str], List[str]]:
+        """Validate this action using preflight validation.
+        
+        Returns:
+            Tuple of (is_valid, errors, warnings)
+        """
+        validator = PreflightValidator()
+        return validator.validate_action(self)
 
 
 @dataclass
@@ -68,10 +79,11 @@ class SyncConfig:
 
 
 class ConfigManager:
-    def __init__(self, path: Path = CONFIG_PATH):
+    def __init__(self, path: Path = CONFIG_PATH, skip_validation: bool = False):
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.config = SyncConfig()
+        self.skip_validation = skip_validation
         if self.path.exists():
             self.load()
         else:
@@ -84,7 +96,23 @@ class ConfigManager:
         self.config = SyncConfig(sync_tool=raw.get("sync_tool", "rsync"), actions=actions)
         return self.config
 
-    def save(self) -> None:
+    def save(self, validate: bool = True) -> None:
+        """Save configuration with optional validation.
+        
+        Args:
+            validate: If True, run preflight validation before saving.
+                     Raises ValueError if validation fails.
+        """
+        if validate and not self.skip_validation:
+            is_valid, errors, warnings = self.validate()
+            if not is_valid:
+                raise ValueError(
+                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                )
+            # Log warnings but don't block save
+            for warning in warnings:
+                logging.warning("Config warning: %s", warning)
+
         data = {
             "sync_tool": self.config.sync_tool,
             "actions": [asdict(a) for a in self.config.actions],
@@ -92,7 +120,15 @@ class ConfigManager:
         with self.path.open("w", encoding="utf-8") as handle:
             yaml.safe_dump(data, handle, sort_keys=False)
 
-    def export(self, target: Path) -> Path:
+    def export(self, target: Path, validate: bool = True) -> Path:
+        """Export configuration to a file with optional validation."""
+        if validate and not self.skip_validation:
+            is_valid, errors, warnings = self.validate()
+            if not is_valid:
+                raise ValueError(
+                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                )
+
         target.parent.mkdir(parents=True, exist_ok=True)
         with target.open("w", encoding="utf-8") as handle:
             yaml.safe_dump(
@@ -105,25 +141,64 @@ class ConfigManager:
             )
         return target
 
-    def import_file(self, source: Path) -> SyncConfig:
+    def import_file(self, source: Path, validate: bool = True) -> SyncConfig:
+        """Import configuration from a file with optional validation."""
         with source.open("r", encoding="utf-8") as handle:
             payload = yaml.safe_load(handle)
         actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
         self.config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)
-        self.save()
+        if validate and not self.skip_validation:
+            is_valid, errors, warnings = self.validate()
+            if not is_valid:
+                raise ValueError(
+                    "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                )
+        self.save(validate=False)  # Already validated
         return self.config
 
     def ensure_default(self) -> None:
         if not self.config.actions:
+            # Use a safe default that doesn't create recursive backups under home
             sample = SyncAction(
-                name="home-backup",
-                src_path=str(Path.home()),
-                dst_path=str(Path.home() / "dir-sync-backups"),
+                name="documents-backup",
+                src_path=str(Path.home() / "Documents"),
+                dst_path=str(Path.home() / "dir-sync-backups" / "documents"),
                 method="one_way",
                 action_type="manual",
             )
             self.config.actions.append(sample)
             self.save()
+
+    def validate(self) -> Tuple[bool, List[str], List[str]]:
+        """Validate entire configuration using preflight validation.
+        
+        Returns:
+            Tuple of (is_valid, errors, warnings)
+        """
+        validator = ConfigValidator()
+        return validator.validate_config(self.config.actions)
+
+    def add_action(self, action: SyncAction, validate: bool = True) -> None:
+        """Add an action with optional validation."""
+        if validate and not self.skip_validation:
+            is_valid, errors, warnings = action.validate()
+            if not is_valid:
+                raise ValueError(
+                    "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                )
+        self.config.add_action(action)
+        self.save(validate=validate)
+
+    def update_action(self, action: SyncAction, validate: bool = True) -> None:
+        """Update an action with optional validation."""
+        if validate and not self.skip_validation:
+            is_valid, errors, warnings = action.validate()
+            if not is_valid:
+                raise ValueError(
+                    "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
+                )
+        self.config.update_action(action)
+        self.save(validate=validate)
 
 
 __all__ = [

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -142,17 +142,32 @@ class ConfigManager:
         return target
 
     def import_file(self, source: Path, validate: bool = True) -> SyncConfig:
-        """Import configuration from a file with optional validation."""
+        """Import configuration from a file with optional validation.
+        
+        Note: Validates imported config BEFORE mutating manager state to prevent
+        partial state corruption on validation failure.
+        """
         with source.open("r", encoding="utf-8") as handle:
             payload = yaml.safe_load(handle)
         actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
-        self.config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)
+        
+        # Create temporary config for validation (don't mutate self.config yet)
+        temp_config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)
+        
         if validate and not self.skip_validation:
-            is_valid, errors, warnings = self.validate()
+            # Validate the temp config before assigning
+            validator = ConfigValidator()
+            is_valid, errors, warnings = validator.validate_config(temp_config.actions)
             if not is_valid:
                 raise ValueError(
                     "Configuration validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
                 )
+            # Log warnings but don't block import
+            for warning in warnings:
+                logging.warning("Config warning: %s", warning)
+        
+        # Only mutate state after validation passes
+        self.config = temp_config
         self.save(validate=False)  # Already validated
         return self.config
 

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -96,6 +96,8 @@ class ConfigManager:
     def load(self) -> SyncConfig:
         with self.path.open("r", encoding="utf-8") as handle:
             raw = yaml.safe_load(handle) or {}
+        if not isinstance(raw, dict):
+            raise ValueError("Configuration file must be a YAML mapping at the top level.")
         actions = [SyncAction(**item).normalize() for item in raw.get("actions", [])]
         self.config = SyncConfig(sync_tool=raw.get("sync_tool", "rsync"), actions=actions)
         return self.config

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -220,6 +220,7 @@ class ConfigManager:
 
     def add_action(self, action: SyncAction, validate: bool = True) -> None:
         """Add an action with optional validation."""
+        save_validate = validate
         if validate and not self.skip_validation:
             is_valid, errors, warnings = action.validate()
             if not is_valid:
@@ -237,12 +238,14 @@ class ConfigManager:
                 raise ValueError("Configuration validation failed:\n" + error_lines)
             for warning in warnings:
                 _logger.warning("Config warning: %s", warning)
+            save_validate = False
 
         self.config.add_action(action)
-        self.save(validate=validate)
+        self.save(validate=save_validate)
 
     def update_action(self, action: SyncAction, validate: bool = True) -> None:
         """Update an action with optional validation."""
+        save_validate = validate
         if validate and not self.skip_validation:
             is_valid, errors, warnings = action.validate()
             if not is_valid:
@@ -260,12 +263,14 @@ class ConfigManager:
                 raise ValueError("Configuration validation failed:\n" + error_lines)
             for warning in warnings:
                 _logger.warning("Config warning: %s", warning)
+            save_validate = False
 
         self.config.update_action(action)
-        self.save(validate=validate)
+        self.save(validate=save_validate)
 
     def remove_action(self, name: str, validate: bool = True) -> None:
         """Remove an action with optional validation of the resulting config."""
+        save_validate = validate
         if validate and not self.skip_validation:
             candidate_config = deepcopy(self.config)
             candidate_config.remove_action(name)
@@ -275,9 +280,10 @@ class ConfigManager:
                 raise ValueError("Configuration validation failed:\n" + error_lines)
             for warning in warnings:
                 _logger.warning("Config warning: %s", warning)
+            save_validate = False
 
         self.config.remove_action(name)
-        self.save(validate=validate)
+        self.save(validate=save_validate)
 
 
 __all__ = [

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -98,7 +98,15 @@ class ConfigManager:
             raw = yaml.safe_load(handle) or {}
         if not isinstance(raw, dict):
             raise ValueError("Configuration file must be a YAML mapping at the top level.")
-        actions = [SyncAction(**item).normalize() for item in raw.get("actions", [])]
+        raw_actions = raw.get("actions", [])
+        if not isinstance(raw_actions, list):
+            raise ValueError("Configuration field 'actions' must be a list.")
+
+        actions = []
+        for index, item in enumerate(raw_actions):
+            if not isinstance(item, dict):
+                raise ValueError(f"Configuration action at index {index} must be a mapping.")
+            actions.append(SyncAction(**item).normalize())
         self.config = SyncConfig(sync_tool=raw.get("sync_tool", "rsync"), actions=actions)
         return self.config
 
@@ -196,12 +204,8 @@ class ConfigManager:
             if docs.exists() and docs.is_dir():
                 default_src = docs
             else:
-                try:
-                    docs.mkdir(parents=True, exist_ok=True)
-                    default_src = docs
-                except OSError:
-                    fallback_src.mkdir(parents=True, exist_ok=True)
-                    default_src = fallback_src
+                fallback_src.mkdir(parents=True, exist_ok=True)
+                default_src = fallback_src
 
             dst_path = home / "dir-sync-backups"
             if not dst_path.exists():

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -153,6 +153,8 @@ class ConfigManager:
         """
         with source.open("r", encoding="utf-8") as handle:
             payload = yaml.safe_load(handle) or {}  # Default to empty dict if file is empty
+        if not isinstance(payload, dict):
+            raise ValueError("Imported configuration must be a YAML mapping at the top level.")
         actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
 
         # Create temporary config for validation (don't mutate self.config yet)

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -251,7 +251,8 @@ class ConfigManager:
                 method="one_way",
                 action_type="manual",
             )
-            self.add_action(sample, validate=not self.skip_validation)
+            self.config.add_action(sample)
+            self.save(validate=False)
 
     def validate(self) -> Tuple[bool, List[str], List[str]]:
         """Validate entire configuration using preflight validation.

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -155,7 +155,17 @@ class ConfigManager:
             payload = yaml.safe_load(handle) or {}  # Default to empty dict if file is empty
         if not isinstance(payload, dict):
             raise ValueError("Imported configuration must be a YAML mapping at the top level.")
-        actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
+        raw_actions = payload.get("actions", [])
+        if not isinstance(raw_actions, list):
+            raise ValueError("Imported configuration field 'actions' must be a list.")
+
+        actions = []
+        for index, item in enumerate(raw_actions):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Imported configuration action at index {index} must be a mapping."
+                )
+            actions.append(SyncAction(**item).normalize())
 
         # Create temporary config for validation (don't mutate self.config yet)
         temp_config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -51,7 +51,17 @@ class SyncAction:
             Tuple of (is_valid, errors, warnings)
         """
         validator = PreflightValidator()
-        return validator.validate_action(self)
+        is_valid, errors, warnings = validator.validate_action(self)
+
+        # Keep validate() aligned with normalize()-time constraints without
+        # mutating the current action instance.
+        try:
+            deepcopy(self).normalize()
+        except ValueError as exc:
+            errors = [*errors, str(exc)]
+            is_valid = False
+
+        return is_valid, errors, warnings
 
 
 @dataclass
@@ -266,8 +276,6 @@ class ConfigManager:
                 raise ValueError(
                     "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
                 )
-            for warning in warnings:
-                _logger.warning("Action '%s' warning: %s", action.name, warning)
 
             candidate_config = deepcopy(self.config)
             candidate_config.add_action(deepcopy(action))
@@ -291,8 +299,6 @@ class ConfigManager:
                 raise ValueError(
                     "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
                 )
-            for warning in warnings:
-                _logger.warning("Action '%s' warning: %s", action.name, warning)
 
             candidate_config = deepcopy(self.config)
             candidate_config.update_action(deepcopy(action))

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -45,7 +46,7 @@ class SyncAction:
 
     def validate(self) -> Tuple[bool, List[str], List[str]]:
         """Validate this action using preflight validation.
-        
+
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
@@ -101,7 +102,7 @@ class ConfigManager:
 
     def save(self, validate: bool = True) -> None:
         """Save configuration with optional validation.
-        
+
         Args:
             validate: If True, run preflight validation before saving.
                      Raises ValueError if validation fails.
@@ -110,9 +111,7 @@ class ConfigManager:
             is_valid, errors, warnings = self.validate()
             if not is_valid:
                 error_lines = "\n".join("  - {}".format(e) for e in errors)
-                raise ValueError(
-                    "Configuration validation failed:\n" + error_lines
-                )
+                raise ValueError("Configuration validation failed:\n" + error_lines)
             # Log warnings but don't block save
             for warning in warnings:
                 _logger.warning("Config warning: %s", warning)
@@ -130,9 +129,9 @@ class ConfigManager:
             is_valid, errors, warnings = self.validate()
             if not is_valid:
                 error_lines = "\n".join("  - {}".format(e) for e in errors)
-                raise ValueError(
-                    "Configuration validation failed:\n" + error_lines
-                )
+                raise ValueError("Configuration validation failed:\n" + error_lines)
+            for warning in warnings:
+                _logger.warning("Config warning: %s", warning)
 
         target.parent.mkdir(parents=True, exist_ok=True)
         with target.open("w", encoding="utf-8") as handle:
@@ -148,30 +147,28 @@ class ConfigManager:
 
     def import_file(self, source: Path, validate: bool = True) -> SyncConfig:
         """Import configuration from a file with optional validation.
-        
+
         Note: Validates imported config BEFORE mutating manager state to prevent
         partial state corruption on validation failure.
         """
         with source.open("r", encoding="utf-8") as handle:
             payload = yaml.safe_load(handle) or {}  # Default to empty dict if file is empty
         actions = [SyncAction(**item).normalize() for item in payload.get("actions", [])]
-        
+
         # Create temporary config for validation (don't mutate self.config yet)
         temp_config = SyncConfig(sync_tool=payload.get("sync_tool", "rsync"), actions=actions)
-        
+
         if validate and not self.skip_validation:
             # Validate the temp config before assigning
             validator = ConfigValidator()
             is_valid, errors, warnings = validator.validate_config(temp_config.actions)
             if not is_valid:
                 error_lines = "\n".join("  - {}".format(e) for e in errors)
-                raise ValueError(
-                    "Configuration validation failed:\n" + error_lines
-                )
+                raise ValueError("Configuration validation failed:\n" + error_lines)
             # Log warnings but don't block import
             for warning in warnings:
-                logging.warning("Config warning: %s", warning)
-        
+                _logger.warning("Config warning: %s", warning)
+
         # Only mutate state after validation passes
         self.config = temp_config
         self.save(validate=False)  # Already validated
@@ -203,17 +200,21 @@ class ConfigManager:
                 method="one_way",
                 action_type="manual",
             )
-            self.config.actions.append(sample)
-            self.save()
+            self.add_action(sample, validate=not self.skip_validation)
 
     def validate(self) -> Tuple[bool, List[str], List[str]]:
         """Validate entire configuration using preflight validation.
-        
+
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
         validator = ConfigValidator()
         return validator.validate_config(self.config.actions)
+
+    def _validate_actions(self, actions: List[SyncAction]) -> Tuple[bool, List[str], List[str]]:
+        """Validate a prospective action list without mutating manager state."""
+        validator = ConfigValidator()
+        return validator.validate_config(actions)
 
     def add_action(self, action: SyncAction, validate: bool = True) -> None:
         """Add an action with optional validation."""
@@ -223,6 +224,18 @@ class ConfigManager:
                 raise ValueError(
                     "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
                 )
+            for warning in warnings:
+                _logger.warning("Action '%s' warning: %s", action.name, warning)
+
+            candidate_config = deepcopy(self.config)
+            candidate_config.add_action(deepcopy(action))
+            is_valid, errors, warnings = self._validate_actions(candidate_config.actions)
+            if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
+                raise ValueError("Configuration validation failed:\n" + error_lines)
+            for warning in warnings:
+                _logger.warning("Config warning: %s", warning)
+
         self.config.add_action(action)
         self.save(validate=validate)
 
@@ -234,7 +247,34 @@ class ConfigManager:
                 raise ValueError(
                     "Action validation failed:\n" + "\n".join("  - {}".format(e) for e in errors)
                 )
+            for warning in warnings:
+                _logger.warning("Action '%s' warning: %s", action.name, warning)
+
+            candidate_config = deepcopy(self.config)
+            candidate_config.update_action(deepcopy(action))
+            is_valid, errors, warnings = self._validate_actions(candidate_config.actions)
+            if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
+                raise ValueError("Configuration validation failed:\n" + error_lines)
+            for warning in warnings:
+                _logger.warning("Config warning: %s", warning)
+
         self.config.update_action(action)
+        self.save(validate=validate)
+
+    def remove_action(self, name: str, validate: bool = True) -> None:
+        """Remove an action with optional validation of the resulting config."""
+        if validate and not self.skip_validation:
+            candidate_config = deepcopy(self.config)
+            candidate_config.remove_action(name)
+            is_valid, errors, warnings = self._validate_actions(candidate_config.actions)
+            if not is_valid:
+                error_lines = "\n".join("  - {}".format(e) for e in errors)
+                raise ValueError("Configuration validation failed:\n" + error_lines)
+            for warning in warnings:
+                _logger.warning("Config warning: %s", warning)
+
+        self.config.remove_action(name)
         self.save(validate=validate)
 
 

--- a/src/dirsync/config.py
+++ b/src/dirsync/config.py
@@ -176,24 +176,26 @@ class ConfigManager:
 
     def ensure_default(self) -> None:
         if not self.config.actions:
-            # Try to find an existing directory for the default backup
-            # Use Documents if it exists, otherwise fall back to home
             home = Path.home()
             docs = home / "Documents"
+            fallback_src = home / "dir-sync-source"
             if docs.exists() and docs.is_dir():
-                default_src = str(docs)
+                default_src = docs
             else:
-                # Fallback to home if Documents doesn't exist
-                default_src = str(home)
-            
-            # Destination is always under dir-sync-backups subfolder
+                try:
+                    docs.mkdir(parents=True, exist_ok=True)
+                    default_src = docs
+                except OSError:
+                    fallback_src.mkdir(parents=True, exist_ok=True)
+                    default_src = fallback_src
+
             dst_path = home / "dir-sync-backups"
             if not dst_path.exists():
                 dst_path.mkdir(parents=True, exist_ok=True)
-            
+
             sample = SyncAction(
                 name="documents-backup",
-                src_path=default_src,
+                src_path=str(default_src),
                 dst_path=str(dst_path / "documents"),
                 method="one_way",
                 action_type="manual",

--- a/src/dirsync/toolbar.py
+++ b/src/dirsync/toolbar.py
@@ -209,7 +209,11 @@ class ToolbarController:
         root.destroy()
         if not source:
             return
-        self.manager.import_file(Path(source))
+        try:
+            self.manager.import_file(Path(source))
+        except ValueError as exc:
+            alert(str(exc))
+            return
         self.refresh()
         alert(f"Imported {source}")
 

--- a/src/dirsync/toolbar.py
+++ b/src/dirsync/toolbar.py
@@ -195,7 +195,11 @@ class ToolbarController:
         root.destroy()
         if not target:
             return
-        self.manager.export(Path(target))
+        try:
+            self.manager.export(Path(target))
+        except ValueError as exc:
+            alert(str(exc))
+            return
         alert(f"Exported config to {target}")
 
     def _import_config(self):

--- a/src/dirsync/ui_config.py
+++ b/src/dirsync/ui_config.py
@@ -300,19 +300,25 @@ class ConfigWindow:
                 dst_device_id=dst_device_id_var.get().strip() or None,
                 dst_path_on_device=dst_path_on_device_var.get().strip() or None,
             )
-            if create:
-                self.manager.config.add_action(payload)
-            else:
-                self.manager.config.update_action(payload)
-            self.manager.save()
+            try:
+                if create:
+                    self.manager.add_action(payload)
+                else:
+                    self.manager.update_action(payload)
+            except ValueError as exc:
+                alert(str(exc))
+                return
             root.destroy()
 
         def on_delete():
             if create:
                 root.destroy()
                 return
-            self.manager.config.remove_action(action.name)
-            self.manager.save()
+            try:
+                self.manager.remove_action(action.name)
+            except ValueError as exc:
+                alert(str(exc))
+                return
             root.destroy()
 
         action_buttons = ttk.Frame(content)

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -97,6 +97,19 @@ class PreflightValidator:
                     src_expanded
                 )
             )
+        elif not src_expanded.is_dir():
+            self.errors.append(
+                "Source path must be a directory: '{}'. "
+                "File sources are not supported by the sync executor.".format(src_expanded)
+            )
+
+        # If destination exists, it must also be a directory.
+        if dst_expanded.exists() and not dst_expanded.is_dir():
+            self.errors.append(
+                "Destination path must be a directory when it already exists: '{}'. ".format(
+                    dst_expanded
+                )
+            )
 
         # Check source equals destination
         if src_expanded == dst_expanded:

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -23,7 +23,7 @@ class PreflightValidator:
     - destructive profile warnings
     """
 
-    # Paths that are dangerous to use as destinations for automatic sync.
+    # Paths that are dangerous to use as destinations and should trigger warnings.
     # Note: Excludes /home to avoid false positives for normal user destinations.
     # On Windows, dangerous system paths are handled via WINDOWS_DANGEROUS_DESTINATIONS.
     DANGEROUS_DESTINATIONS = (
@@ -135,7 +135,7 @@ class PreflightValidator:
         if self._is_dangerous_destination(dst_expanded):
             self.warnings.append(
                 "Destination '{}' is a system-critical path. "
-                "Automatic sync to this location is not recommended.".format(dst_expanded)
+                "Syncing to this location is not recommended.".format(dst_expanded)
             )
 
         # Check cron expression if scheduled

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -147,15 +147,17 @@ class PreflightValidator:
                     "Please provide a schedule (e.g., '0 2 * * *')."
                 )
             else:
+                schedule = str(action.schedule).strip()
+
                 # Use croniter to validate cron expressions for compatibility with runtime scheduler
                 try:
-                    croniter(action.schedule)
-                except (KeyError, ValueError) as e:
+                    croniter(schedule)
+                except (KeyError, TypeError, ValueError) as e:
                     self.errors.append(
                         "Invalid cron expression: '{}'. "
                         "Croniter error: {}. "
                         "Please use valid cron format (e.g., '0 2 * * *').".format(
-                            action.schedule, e
+                            schedule, e
                         )
                     )
 

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -1,6 +1,5 @@
-import re
 from pathlib import Path
-from typing import List, Tuple
+from typing import Tuple
 
 
 class PreflightValidator:
@@ -17,9 +16,9 @@ class PreflightValidator:
     """
 
     # Paths that are dangerous to use as destinations for automatic sync
+    # Note: Excludes /home to avoid false positives for normal user destinations
     DANGEROUS_DESTINATIONS = (
         "/",
-        "/home",
         "/etc",
         "/usr",
         "/var",
@@ -35,14 +34,31 @@ class PreflightValidator:
         self.errors = []
         self.warnings = []
 
-    def validate_action(self, action):
+    def validate_action(self, action, action_name=None):
         """Validate a single sync action.
         
+        Args:
+            action: SyncAction to validate
+            action_name: Optional name for error prefixing
+            
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
         self.errors = []
         self.warnings = []
+
+        # Check for missing/empty source FIRST (before path resolution)
+        if not action.src_path or not str(action.src_path).strip():
+            self.errors.append("Source path is missing or empty")
+
+        # Check for missing/empty destination FIRST (before path resolution)
+        if not action.dst_path or not str(action.dst_path).strip():
+            self.errors.append("Destination path is missing or empty")
+
+        # If we have empty paths, return early to avoid misleading errors
+        if not action.src_path or not str(action.src_path).strip() or \
+           not action.dst_path or not str(action.dst_path).strip():
+            return False, self.errors, self.warnings
 
         # Normalize paths for comparison
         try:
@@ -52,13 +68,12 @@ class PreflightValidator:
             self.errors.append("Cannot resolve paths: {}".format(e))
             return False, self.errors, self.warnings
 
-        # Check for missing source
-        if not action.src_path or not action.src_path.strip():
-            self.errors.append("Source path is missing or empty")
-
-        # Check for missing destination
-        if not action.dst_path or not action.dst_path.strip():
-            self.errors.append("Destination path is missing or empty")
+        # Check source path exists (destination can be created by executor)
+        if not src_expanded.exists():
+            self.errors.append(
+                "Source path does not exist: '{}'. "
+                "Please ensure the source directory exists before creating a sync action.".format(src_expanded)
+            )
 
         # Check source equals destination
         if src_expanded == dst_expanded:
@@ -133,6 +148,8 @@ class PreflightValidator:
         
         Supports standard 5-field cron: minute hour day month weekday
         Also supports special strings: @yearly, @monthly, @weekly, @daily, @hourly, @reboot
+        
+        Note: Day of week accepts both 0 and 7 for Sunday (croniter compatibility).
         """
         special_expressions = ("@yearly", "@monthly", "@weekly", "@daily", "@hourly", "@reboot")
         if expression.lower() in special_expressions:
@@ -143,12 +160,13 @@ class PreflightValidator:
             return False
 
         # Validate each field with basic ranges
+        # Note: day of week allows 0-7 (both 0 and 7 represent Sunday for croniter compatibility)
         ranges = [
             (0, 59),   # minute
             (0, 23),   # hour
             (1, 31),   # day of month
             (1, 12),   # month
-            (0, 6),    # day of week
+            (0, 7),    # day of week (0 and 7 are both Sunday)
         ]
 
         for part, (min_val, max_val) in zip(parts, ranges):
@@ -233,9 +251,12 @@ class ConfigValidator:
 
             # Validate individual action
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
-            self.errors.extend(errors)
-            self.warnings.extend(warnings)
+            is_valid, errors, warnings = validator.validate_action(action, action_name=action.name)
+            # Prefix errors and warnings with action name for clarity
+            for err in errors:
+                self.errors.append("Action '{}': {}".format(action.name, err))
+            for warn in warnings:
+                self.warnings.append("Action '{}': {}".format(action.name, warn))
 
         is_valid = len(self.errors) == 0
         return is_valid, self.errors, self.warnings

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -106,7 +106,7 @@ class PreflightValidator:
         # If destination exists, it must also be a directory.
         if dst_expanded.exists() and not dst_expanded.is_dir():
             self.errors.append(
-                "Destination path must be a directory when it already exists: '{}'. ".format(
+                "Destination path must be a directory when it already exists: '{}'.".format(
                     dst_expanded
                 )
             )

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -1,5 +1,9 @@
+import os
+import sys
 from pathlib import Path
 from typing import Tuple
+
+from croniter import croniter
 
 
 class PreflightValidator:
@@ -10,13 +14,13 @@ class PreflightValidator:
     - destination nested inside source (would cause recursion)
     - source nested inside destination (would cause unexpected deletes)
     - missing source path
-    - missing or unavailable sync backend
     - invalid cron expressions
     - destructive profile warnings
     """
 
     # Paths that are dangerous to use as destinations for automatic sync
     # Note: Excludes /home to avoid false positives for normal user destinations
+    # On Windows: C:\Windows, C:\Program Files, etc. are handled via Path.drive checks
     DANGEROUS_DESTINATIONS = (
         "/",
         "/etc",
@@ -30,16 +34,24 @@ class PreflightValidator:
         "/sys",
     )
 
+    # Windows dangerous paths
+    WINDOWS_DANGEROUS_DESTINATIONS = (
+        "C:\\Windows",
+        "C:\\Program Files",
+        "C:\\Program Files (x86)",
+        "C:\\ProgramData",
+        "C:\\Users\\Public",
+    )
+
     def __init__(self):
         self.errors = []
         self.warnings = []
 
-    def validate_action(self, action, action_name=None):
+    def validate_action(self, action):
         """Validate a single sync action.
         
         Args:
             action: SyncAction to validate
-            action_name: Optional name for error prefixing
             
         Returns:
             Tuple of (is_valid, errors, warnings)
@@ -104,12 +116,23 @@ class PreflightValidator:
             )
 
         # Check cron expression if scheduled
-        if action.action_type == "scheduled" and action.schedule:
-            if not self._is_valid_cron(action.schedule):
+        if action.action_type == "scheduled":
+            # If action_type is scheduled, schedule must be provided and valid
+            if not action.schedule or not str(action.schedule).strip():
                 self.errors.append(
-                    "Invalid cron expression: '{}'. "
-                    "Please use valid cron format (e.g., '0 2 * * *').".format(action.schedule)
+                    "Scheduled action requires a valid cron expression. "
+                    "Please provide a schedule (e.g., '0 2 * * *')."
                 )
+            else:
+                # Use croniter to validate cron expressions for compatibility with runtime scheduler
+                try:
+                    croniter(action.schedule)
+                except (KeyError, ValueError) as e:
+                    self.errors.append(
+                        "Invalid cron expression: '{}'. "
+                        "Croniter error: {}. "
+                        "Please use valid cron format (e.g., '0 2 * * *').".format(action.schedule, e)
+                    )
 
         # Check method-specific requirements
         if action.method == "two_way":
@@ -137,87 +160,27 @@ class PreflightValidator:
             return False
 
     def _is_dangerous_destination(self, path):
-        """Check if path is a dangerous system location."""
-        path_str = str(path)
-        return path_str in self.DANGEROUS_DESTINATIONS or any(
-            path_str.startswith(dangerous + "/") for dangerous in self.DANGEROUS_DESTINATIONS
-        )
-
-    def _is_valid_cron(self, expression):
-        """Validate cron expression format.
+        """Check if path is a dangerous system location.
         
-        Supports standard 5-field cron: minute hour day month weekday
-        Also supports special strings: @yearly, @monthly, @weekly, @daily, @hourly, @reboot
-        
-        Note: Day of week accepts both 0 and 7 for Sunday (croniter compatibility).
+        Handles both Unix-style paths and Windows paths.
         """
-        special_expressions = ("@yearly", "@monthly", "@weekly", "@daily", "@hourly", "@reboot")
-        if expression.lower() in special_expressions:
+        path_str = str(path)
+        
+        # Check Unix-style dangerous destinations
+        if path_str in self.DANGEROUS_DESTINATIONS or any(
+            path_str.startswith(dangerous + "/") for dangerous in self.DANGEROUS_DESTINATIONS
+        ):
             return True
-
-        parts = expression.split()
-        if len(parts) != 5:
-            return False
-
-        # Validate each field with basic ranges
-        # Note: day of week allows 0-7 (both 0 and 7 represent Sunday for croniter compatibility)
-        ranges = [
-            (0, 59),   # minute
-            (0, 23),   # hour
-            (1, 31),   # day of month
-            (1, 12),   # month
-            (0, 7),    # day of week (0 and 7 are both Sunday)
-        ]
-
-        for part, (min_val, max_val) in zip(parts, ranges):
-            if not self._is_valid_cron_field(part, min_val, max_val):
-                return False
-
-        return True
-
-    def _is_valid_cron_field(self, field, min_val, max_val):
-        """Validate a single cron field."""
-        # Handle wildcard
-        if field == "*":
-            return True
-
-        # Handle step values (e.g., */5, 1-10/2)
-        if "/" in field:
-            parts = field.split("/")
-            if len(parts) != 2:
-                return False
-            base, step = parts
-            if not step.isdigit() or int(step) <= 0:
-                return False
-            if base == "*":
-                return True
-            field = base  # Validate the base part
-
-        # Handle ranges (e.g., 1-5)
-        if "-" in field:
-            range_parts = field.split("-")
-            if len(range_parts) != 2:
-                return False
-            for part in range_parts:
-                if not part.isdigit():
-                    return False
-                val = int(part)
-                if val < min_val or val > max_val:
-                    return False
-            return True
-
-        # Handle comma-separated lists (e.g., 1,3,5)
-        if "," in field:
-            for part in field.split(","):
-                if not self._is_valid_cron_field(part, min_val, max_val):
-                    return False
-            return True
-
-        # Single value
-        if not field.isdigit():
-            return False
-        val = int(field)
-        return min_val <= val <= max_val
+        
+        # Check Windows-style dangerous destinations
+        if sys.platform.startswith("win"):
+            path_upper = path_str.upper()
+            for dangerous in self.WINDOWS_DANGEROUS_DESTINATIONS:
+                dangerous_upper = dangerous.upper()
+                if path_upper == dangerous_upper or path_upper.startswith(dangerous_upper + "\\"):
+                    return True
+        
+        return False
 
     def _looks_like_destructive_sync(self, action):
         """Check if sync configuration looks potentially destructive."""

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -82,7 +82,9 @@ class PreflightValidator:
         if not src_expanded.exists():
             self.errors.append(
                 "Source path does not exist: '{}'. "
-                "Please ensure the source directory exists before creating a sync action.".format(src_expanded)
+                "Please ensure the source directory exists before creating a sync action.".format(
+                    src_expanded
+                )
             )
 
         # Check source equals destination
@@ -129,7 +131,9 @@ class PreflightValidator:
                     self.errors.append(
                         "Invalid cron expression: '{}'. "
                         "Croniter error: {}. "
-                        "Please use valid cron format (e.g., '0 2 * * *').".format(action.schedule, e)
+                        "Please use valid cron format (e.g., '0 2 * * *').".format(
+                            action.schedule, e
+                        )
                     )
 
         # Check method-specific requirements

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class PreflightValidator:
-    """Validates sync actions before they can be saved or executed.
+    """Validates sync actions before they can be saved or imported.
 
     Blocks invalid or dangerous sync definitions covering:
     - source equals destination

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -189,7 +189,7 @@ class PreflightValidator:
 
     def _looks_like_destructive_sync(self, action: SyncAction) -> bool:
         """Check if sync configuration looks potentially destructive."""
-        # One-way sync with no filters to a non-empty-appearing destination
+        # Current heuristic: flag syncs with no include/exclude filters.
         has_no_filters = not action.includes and not action.excludes
         return has_no_filters
 

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -16,9 +16,9 @@ class PreflightValidator:
     - destructive profile warnings
     """
 
-    # Paths that are dangerous to use as destinations for automatic sync
-    # Note: Excludes /home to avoid false positives for normal user destinations
-    # On Windows: C:\Windows, C:\Program Files, etc. are handled via Path.drive checks
+    # Paths that are dangerous to use as destinations for automatic sync.
+    # Note: Excludes /home to avoid false positives for normal user destinations.
+    # On Windows, dangerous system paths are handled via WINDOWS_DANGEROUS_DESTINATIONS.
     DANGEROUS_DESTINATIONS = (
         "/",
         "/etc",
@@ -105,7 +105,7 @@ class PreflightValidator:
         if self._is_subpath(src_expanded, dst_expanded):
             self.errors.append(
                 "Source is nested inside destination. "
-                "This may cause unexpected deletions during two-way sync."
+                "This may cause unexpected deletions during sync."
             )
 
         # Check for dangerous destination paths

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -1,0 +1,247 @@
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+
+class PreflightValidator:
+    """Validates sync actions before they can be saved or executed.
+    
+    Blocks invalid or dangerous sync definitions covering:
+    - source equals destination
+    - destination nested inside source (would cause recursion)
+    - source nested inside destination (would cause unexpected deletes)
+    - missing source path
+    - missing or unavailable sync backend
+    - invalid cron expressions
+    - destructive profile warnings
+    """
+
+    # Paths that are dangerous to use as destinations for automatic sync
+    DANGEROUS_DESTINATIONS = (
+        "/",
+        "/home",
+        "/etc",
+        "/usr",
+        "/var",
+        "/bin",
+        "/sbin",
+        "/boot",
+        "/dev",
+        "/proc",
+        "/sys",
+    )
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def validate_action(self, action):
+        """Validate a single sync action.
+        
+        Returns:
+            Tuple of (is_valid, errors, warnings)
+        """
+        self.errors = []
+        self.warnings = []
+
+        # Normalize paths for comparison
+        try:
+            src_expanded = Path(action.src_path).expanduser().resolve()
+            dst_expanded = Path(action.dst_path).expanduser().resolve()
+        except (OSError, RuntimeError) as e:
+            self.errors.append("Cannot resolve paths: {}".format(e))
+            return False, self.errors, self.warnings
+
+        # Check for missing source
+        if not action.src_path or not action.src_path.strip():
+            self.errors.append("Source path is missing or empty")
+
+        # Check for missing destination
+        if not action.dst_path or not action.dst_path.strip():
+            self.errors.append("Destination path is missing or empty")
+
+        # Check source equals destination
+        if src_expanded == dst_expanded:
+            self.errors.append(
+                "Source and destination paths are identical. "
+                "This would cause data loss."
+            )
+
+        # Check destination nested inside source (recursion risk)
+        if self._is_subpath(dst_expanded, src_expanded):
+            self.errors.append(
+                "Destination is nested inside source. "
+                "This would cause infinite recursion during sync."
+            )
+
+        # Check source nested inside destination (unexpected deletes risk)
+        if self._is_subpath(src_expanded, dst_expanded):
+            self.errors.append(
+                "Source is nested inside destination. "
+                "This may cause unexpected deletions during two-way sync."
+            )
+
+        # Check for dangerous destination paths
+        if self._is_dangerous_destination(dst_expanded):
+            self.warnings.append(
+                "Destination '{}' is a system-critical path. "
+                "Automatic sync to this location is not recommended.".format(dst_expanded)
+            )
+
+        # Check cron expression if scheduled
+        if action.action_type == "scheduled" and action.schedule:
+            if not self._is_valid_cron(action.schedule):
+                self.errors.append(
+                    "Invalid cron expression: '{}'. "
+                    "Please use valid cron format (e.g., '0 2 * * *').".format(action.schedule)
+                )
+
+        # Check method-specific requirements
+        if action.method == "two_way":
+            if not action.src_path or not action.dst_path:
+                self.errors.append(
+                    "Two-way sync requires both source and destination paths."
+                )
+
+        # Check for destructive profile
+        if action.method == "one_way" and self._looks_like_destructive_sync(action):
+            self.warnings.append(
+                "One-way sync with no includes/excludes may overwrite all destination contents. "
+                "Consider adding include/exclude patterns for safety."
+            )
+
+        is_valid = len(self.errors) == 0
+        return is_valid, self.errors, self.warnings
+
+    def _is_subpath(self, path, parent):
+        """Check if path is a subpath of parent."""
+        try:
+            path.relative_to(parent)
+            return path != parent  # Exclude exact matches
+        except ValueError:
+            return False
+
+    def _is_dangerous_destination(self, path):
+        """Check if path is a dangerous system location."""
+        path_str = str(path)
+        return path_str in self.DANGEROUS_DESTINATIONS or any(
+            path_str.startswith(dangerous + "/") for dangerous in self.DANGEROUS_DESTINATIONS
+        )
+
+    def _is_valid_cron(self, expression):
+        """Validate cron expression format.
+        
+        Supports standard 5-field cron: minute hour day month weekday
+        Also supports special strings: @yearly, @monthly, @weekly, @daily, @hourly, @reboot
+        """
+        special_expressions = ("@yearly", "@monthly", "@weekly", "@daily", "@hourly", "@reboot")
+        if expression.lower() in special_expressions:
+            return True
+
+        parts = expression.split()
+        if len(parts) != 5:
+            return False
+
+        # Validate each field with basic ranges
+        ranges = [
+            (0, 59),   # minute
+            (0, 23),   # hour
+            (1, 31),   # day of month
+            (1, 12),   # month
+            (0, 6),    # day of week
+        ]
+
+        for part, (min_val, max_val) in zip(parts, ranges):
+            if not self._is_valid_cron_field(part, min_val, max_val):
+                return False
+
+        return True
+
+    def _is_valid_cron_field(self, field, min_val, max_val):
+        """Validate a single cron field."""
+        # Handle wildcard
+        if field == "*":
+            return True
+
+        # Handle step values (e.g., */5, 1-10/2)
+        if "/" in field:
+            parts = field.split("/")
+            if len(parts) != 2:
+                return False
+            base, step = parts
+            if not step.isdigit() or int(step) <= 0:
+                return False
+            if base == "*":
+                return True
+            field = base  # Validate the base part
+
+        # Handle ranges (e.g., 1-5)
+        if "-" in field:
+            range_parts = field.split("-")
+            if len(range_parts) != 2:
+                return False
+            for part in range_parts:
+                if not part.isdigit():
+                    return False
+                val = int(part)
+                if val < min_val or val > max_val:
+                    return False
+            return True
+
+        # Handle comma-separated lists (e.g., 1,3,5)
+        if "," in field:
+            for part in field.split(","):
+                if not self._is_valid_cron_field(part, min_val, max_val):
+                    return False
+            return True
+
+        # Single value
+        if not field.isdigit():
+            return False
+        val = int(field)
+        return min_val <= val <= max_val
+
+    def _looks_like_destructive_sync(self, action):
+        """Check if sync configuration looks potentially destructive."""
+        # One-way sync with no filters to a non-empty-appearing destination
+        has_no_filters = not action.includes and not action.excludes
+        return has_no_filters
+
+
+class ConfigValidator:
+    """Validates entire configuration for cross-action issues."""
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def validate_config(self, actions):
+        """Validate a list of sync actions for cross-action issues.
+        
+        Returns:
+            Tuple of (is_valid, errors, warnings)
+        """
+        self.errors = []
+        self.warnings = []
+
+        action_names = set()
+        for action in actions:
+            # Check for duplicate action names
+            if action.name in action_names:
+                self.errors.append("Duplicate action name: '{}'".format(action.name))
+            action_names.add(action.name)
+
+            # Validate individual action
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            self.errors.extend(errors)
+            self.warnings.extend(warnings)
+
+        is_valid = len(self.errors) == 0
+        return is_valid, self.errors, self.warnings
+
+
+__all__ = [
+    "PreflightValidator",
+    "ConfigValidator",
+]

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -1,7 +1,14 @@
-import sys
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from croniter import croniter
+
+from .constants import IS_WINDOWS
+
+if TYPE_CHECKING:
+    from .config import SyncAction
 
 
 class PreflightValidator:
@@ -41,11 +48,11 @@ class PreflightValidator:
         "C:\\Users\\Public",
     )
 
-    def __init__(self):
-        self.errors = []
-        self.warnings = []
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
 
-    def validate_action(self, action):
+    def validate_action(self, action: SyncAction) -> tuple[bool, list[str], list[str]]:
         """Validate a single sync action.
 
         Args:
@@ -149,7 +156,7 @@ class PreflightValidator:
         is_valid = len(self.errors) == 0
         return is_valid, self.errors, self.warnings
 
-    def _is_subpath(self, path, parent):
+    def _is_subpath(self, path: Path, parent: Path) -> bool:
         """Check if path is a subpath of parent."""
         try:
             path.relative_to(parent)
@@ -157,7 +164,7 @@ class PreflightValidator:
         except ValueError:
             return False
 
-    def _is_dangerous_destination(self, path):
+    def _is_dangerous_destination(self, path: Path) -> bool:
         """Check if path is a dangerous system location.
 
         Handles both Unix-style paths and Windows paths.
@@ -171,7 +178,7 @@ class PreflightValidator:
             return True
 
         # Check Windows-style dangerous destinations
-        if sys.platform.startswith("win"):
+        if IS_WINDOWS:
             path_upper = path_str.upper()
             for dangerous in self.WINDOWS_DANGEROUS_DESTINATIONS:
                 dangerous_upper = dangerous.upper()
@@ -180,7 +187,7 @@ class PreflightValidator:
 
         return False
 
-    def _looks_like_destructive_sync(self, action):
+    def _looks_like_destructive_sync(self, action: SyncAction) -> bool:
         """Check if sync configuration looks potentially destructive."""
         # One-way sync with no filters to a non-empty-appearing destination
         has_no_filters = not action.includes and not action.excludes
@@ -190,11 +197,11 @@ class PreflightValidator:
 class ConfigValidator:
     """Validates entire configuration for cross-action issues."""
 
-    def __init__(self):
-        self.errors = []
-        self.warnings = []
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
 
-    def validate_config(self, actions):
+    def validate_config(self, actions: list[SyncAction]) -> tuple[bool, list[str], list[str]]:
         """Validate a list of sync actions for cross-action issues.
 
         Returns:

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -6,7 +6,7 @@ from croniter import croniter
 
 class PreflightValidator:
     """Validates sync actions before they can be saved or executed.
-    
+
     Blocks invalid or dangerous sync definitions covering:
     - source equals destination
     - destination nested inside source (would cause recursion)
@@ -47,10 +47,10 @@ class PreflightValidator:
 
     def validate_action(self, action):
         """Validate a single sync action.
-        
+
         Args:
             action: SyncAction to validate
-            
+
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
@@ -66,8 +66,12 @@ class PreflightValidator:
             self.errors.append("Destination path is missing or empty")
 
         # If we have empty paths, return early to avoid misleading errors
-        if not action.src_path or not str(action.src_path).strip() or \
-           not action.dst_path or not str(action.dst_path).strip():
+        if (
+            not action.src_path
+            or not str(action.src_path).strip()
+            or not action.dst_path
+            or not str(action.dst_path).strip()
+        ):
             return False, self.errors, self.warnings
 
         # Normalize paths for comparison
@@ -90,8 +94,7 @@ class PreflightValidator:
         # Check source equals destination
         if src_expanded == dst_expanded:
             self.errors.append(
-                "Source and destination paths are identical. "
-                "This would cause data loss."
+                "Source and destination paths are identical. " "This would cause data loss."
             )
 
         # Check destination nested inside source (recursion risk)
@@ -136,13 +139,6 @@ class PreflightValidator:
                         )
                     )
 
-        # Check method-specific requirements
-        if action.method == "two_way":
-            if not action.src_path or not action.dst_path:
-                self.errors.append(
-                    "Two-way sync requires both source and destination paths."
-                )
-
         # Check for destructive profile
         if action.method == "one_way" and self._looks_like_destructive_sync(action):
             self.warnings.append(
@@ -163,17 +159,17 @@ class PreflightValidator:
 
     def _is_dangerous_destination(self, path):
         """Check if path is a dangerous system location.
-        
+
         Handles both Unix-style paths and Windows paths.
         """
         path_str = str(path)
-        
+
         # Check Unix-style dangerous destinations
         if path_str in self.DANGEROUS_DESTINATIONS or any(
             path_str.startswith(dangerous + "/") for dangerous in self.DANGEROUS_DESTINATIONS
         ):
             return True
-        
+
         # Check Windows-style dangerous destinations
         if sys.platform.startswith("win"):
             path_upper = path_str.upper()
@@ -181,7 +177,7 @@ class PreflightValidator:
                 dangerous_upper = dangerous.upper()
                 if path_upper == dangerous_upper or path_upper.startswith(dangerous_upper + "\\"):
                     return True
-        
+
         return False
 
     def _looks_like_destructive_sync(self, action):
@@ -200,7 +196,7 @@ class ConfigValidator:
 
     def validate_config(self, actions):
         """Validate a list of sync actions for cross-action issues.
-        
+
         Returns:
             Tuple of (is_valid, errors, warnings)
         """
@@ -216,7 +212,7 @@ class ConfigValidator:
 
             # Validate individual action
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            _is_valid, errors, warnings = validator.validate_action(action)
             # Prefix errors and warnings with action name for clarity
             for err in errors:
                 self.errors.append("Action '{}': {}".format(action.name, err))

--- a/src/dirsync/validator.py
+++ b/src/dirsync/validator.py
@@ -1,7 +1,5 @@
-import os
 import sys
 from pathlib import Path
-from typing import Tuple
 
 from croniter import croniter
 
@@ -214,7 +212,7 @@ class ConfigValidator:
 
             # Validate individual action
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action, action_name=action.name)
+            is_valid, errors, warnings = validator.validate_action(action)
             # Prefix errors and warnings with action name for clarity
             for err in errors:
                 self.errors.append("Action '{}': {}".format(action.name, err))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,6 +218,22 @@ class TestConfigManager:
         with pytest.raises(ValueError, match="YAML mapping"):
             manager.import_file(source_path)
 
+    def test_load_rejects_falsy_non_mapping_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("false\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="YAML mapping"):
+            ConfigManager(path=config_path)
+
+    def test_import_file_rejects_falsy_non_mapping_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        source_path = tmp_path / "invalid.yml"
+        source_path.write_text("false\n", encoding="utf-8")
+        manager = ConfigManager(path=config_path)
+
+        with pytest.raises(ValueError, match="YAML mapping"):
+            manager.import_file(source_path)
+
     def test_load_rejects_non_list_actions(self, tmp_path):
         config_path = tmp_path / "config.yml"
         config_path.write_text("actions: {}\n", encoding="utf-8")
@@ -231,6 +247,34 @@ class TestConfigManager:
 
         with pytest.raises(ValueError, match="action at index 0 must be a mapping"):
             ConfigManager(path=config_path)
+
+    def test_load_reports_invalid_action_index(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(
+            "actions:\n"
+            "  - name: broken\n"
+            "    src_path: null\n"
+            "    dst_path: /tmp/dst\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=r"action at index 0 is invalid"):
+            ConfigManager(path=config_path)
+
+    def test_import_file_reports_invalid_action_index(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        source_path = tmp_path / "invalid.yml"
+        source_path.write_text(
+            "actions:\n"
+            "  - name: broken\n"
+            "    src_path: null\n"
+            "    dst_path: /tmp/dst\n",
+            encoding="utf-8",
+        )
+        manager = ConfigManager(path=config_path)
+
+        with pytest.raises(ValueError, match=r"action at index 0 is invalid"):
+            manager.import_file(source_path)
 
 
 def test_config_persists_device_binding_fields(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,10 +113,14 @@ class TestConfigManager:
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
         sample = SyncAction(
             name="sample",
-            src_path=str(tmp_path / "src"),
-            dst_path=str(tmp_path / "dst"),
+            src_path=str(src),
+            dst_path=str(dst),
             method="one_way",
             action_type="manual",
         )
@@ -130,10 +134,14 @@ class TestConfigManager:
     def test_roundtrip_with_includes_excludes(self, tmp_path):
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path)
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
         action = SyncAction(
             name="filtered",
-            src_path="/src",
-            dst_path="/dst",
+            src_path=str(src),
+            dst_path=str(dst),
             includes=["*.py", "docs/*"],
             excludes=["*.pyc", "__pycache__/*"],
         )
@@ -149,8 +157,12 @@ class TestConfigManager:
         config_path = tmp_path / "config.yml"
         export_path = tmp_path / "exports" / "export.yml"
         manager = ConfigManager(path=config_path)
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
         manager.config.add_action(
-            SyncAction(name="exp", src_path="/a", dst_path="/b", method="one_way")
+            SyncAction(name="exp", src_path=str(src), dst_path=str(dst), method="one_way")
         )
         manager.save()
         manager.export(export_path)
@@ -172,10 +184,7 @@ class TestConfigManager:
         manager.config.actions = []
         manager.ensure_default()
         assert len(manager.config.actions) == 1
-        # Default action name might be "documents-backup" or "home-backup" depending on Documents folder existence
-        name = manager.config.actions[0].name
-        assert name in ("documents-backup", "home-backup")
-        # Both should use a directory under dir-sync-backups
+        assert manager.config.actions[0].name == "documents-backup"
         assert "dir-sync-backups" in manager.config.actions[0].dst_path
 
     def test_ensure_default_noop_when_actions_exist(self, tmp_path):
@@ -198,10 +207,14 @@ def test_config_persists_device_binding_fields(tmp_path):
     config_path = tmp_path / "config.yml"
     manager = ConfigManager(path=config_path)
     manager.config.actions = []
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
     sample = SyncAction(
         name="usb-sync",
-        src_path=str(tmp_path / "src"),
-        dst_path=str(tmp_path / "dst"),
+        src_path=str(src),
+        dst_path=str(dst),
         method="one_way",
         action_type="auto_on_destination",
         dst_device_id="8D06-A5B2",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,6 +202,13 @@ class TestConfigManager:
         assert manager.config.actions == []
         assert manager.config.sync_tool == "rsync"
 
+    def test_load_rejects_non_mapping_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="YAML mapping"):
+            ConfigManager(path=config_path)
+
     def test_import_file_rejects_non_mapping_yaml(self, tmp_path):
         config_path = tmp_path / "config.yml"
         source_path = tmp_path / "invalid.yml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,28 @@ class TestConfigManager:
         assert len(manager.config.actions) == 1
         assert manager.config.actions[0].name == "keep"
 
+    def test_ensure_default_rejects_file_at_fallback_source(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        monkeypatch.setattr("dirsync.config.Path.home", lambda: tmp_path)
+        (tmp_path / "dir-sync-source").write_text("not a directory", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Default source path .* is not a directory"):
+            manager.ensure_default()
+
+    def test_ensure_default_rejects_file_at_backup_root(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        monkeypatch.setattr("dirsync.config.Path.home", lambda: tmp_path)
+        (tmp_path / "dir-sync-backups").write_text("not a directory", encoding="utf-8")
+
+        with pytest.raises(
+            ValueError, match="Default destination path .* is not a directory"
+        ):
+            manager.ensure_default()
+
     def test_load_empty_file(self, tmp_path):
         config_path = tmp_path / "config.yml"
         config_path.write_text("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -212,11 +212,25 @@ class TestConfigManager:
     def test_import_file_rejects_non_mapping_yaml(self, tmp_path):
         config_path = tmp_path / "config.yml"
         source_path = tmp_path / "invalid.yml"
-        source_path.write_text("- not\n- a\n- mapping\n")
+        source_path.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
         manager = ConfigManager(path=config_path)
 
         with pytest.raises(ValueError, match="YAML mapping"):
             manager.import_file(source_path)
+
+    def test_load_rejects_non_list_actions(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("actions: {}\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="field 'actions' must be a list"):
+            ConfigManager(path=config_path)
+
+    def test_load_rejects_non_mapping_action_items(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("actions:\n  - valid\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="action at index 0 must be a mapping"):
+            ConfigManager(path=config_path)
 
 
 def test_config_persists_device_binding_fields(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,35 @@ class TestSyncActionNormalize:
         result = action.normalize()
         assert result is action
 
+    def test_validate_rejects_unsupported_method(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        action = SyncAction(name="a", src_path=str(src), dst_path=str(dst), method="invalid")
+
+        is_valid, errors, _warnings = action.validate()
+
+        assert not is_valid
+        assert any("Unsupported method" in error for error in errors)
+
+    def test_validate_rejects_unsupported_action_type(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        action = SyncAction(
+            name="a",
+            src_path=str(src),
+            dst_path=str(dst),
+            action_type="invalid",
+        )
+
+        is_valid, errors, _warnings = action.validate()
+
+        assert not is_valid
+        assert any("Unsupported action type" in error for error in errors)
+
 
 # --- SyncConfig ---
 
@@ -297,6 +326,64 @@ class TestConfigManager:
 
         with pytest.raises(ValueError, match=r"action at index 0 is invalid"):
             manager.import_file(source_path)
+
+    def test_add_action_logs_warning_once(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        action = SyncAction(
+            name="warn-add",
+            src_path=str(src),
+            dst_path=str(dst),
+            method="one_way",
+        )
+
+        with caplog.at_level("WARNING"):
+            manager.add_action(action)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert messages == [
+            "Config warning: Action 'warn-add': One-way sync with no includes/excludes may "
+            "overwrite all destination contents. Consider adding include/exclude patterns for "
+            "safety."
+        ]
+
+    def test_update_action_logs_warning_once(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        manager.add_action(
+            SyncAction(
+                name="warn-update",
+                src_path=str(src),
+                dst_path=str(dst),
+                method="two_way",
+            )
+        )
+
+        with caplog.at_level("WARNING"):
+            manager.update_action(
+                SyncAction(
+                    name="warn-update",
+                    src_path=str(src),
+                    dst_path=str(dst),
+                    method="one_way",
+                )
+            )
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert messages == [
+            "Config warning: Action 'warn-update': One-way sync with no includes/excludes may "
+            "overwrite all destination contents. Consider adding include/exclude patterns for "
+            "safety."
+        ]
 
 
 def test_config_persists_device_binding_fields(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,6 +202,15 @@ class TestConfigManager:
         assert manager.config.actions == []
         assert manager.config.sync_tool == "rsync"
 
+    def test_import_file_rejects_non_mapping_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        source_path = tmp_path / "invalid.yml"
+        source_path.write_text("- not\n- a\n- mapping\n")
+        manager = ConfigManager(path=config_path)
+
+        with pytest.raises(ValueError, match="YAML mapping"):
+            manager.import_file(source_path)
+
 
 def test_config_persists_device_binding_fields(tmp_path):
     config_path = tmp_path / "config.yml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,7 +172,11 @@ class TestConfigManager:
         manager.config.actions = []
         manager.ensure_default()
         assert len(manager.config.actions) == 1
-        assert manager.config.actions[0].name == "home-backup"
+        # Default action name might be "documents-backup" or "home-backup" depending on Documents folder existence
+        name = manager.config.actions[0].name
+        assert name in ("documents-backup", "home-backup")
+        # Both should use a directory under dir-sync-backups
+        assert "dir-sync-backups" in manager.config.actions[0].dst_path
 
     def test_ensure_default_noop_when_actions_exist(self, tmp_path):
         config_path = tmp_path / "config.yml"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -16,9 +16,9 @@ class TestPreflightValidatorBasicPaths:
             path.mkdir()
             action = SyncAction(name="test", src_path=str(path), dst_path=str(path))
             validator = PreflightValidator()
-            is_valid, errors, _warnings = validator.validate_action(action)
+            is_valid, _errors, _warnings = validator.validate_action(action)
             assert not is_valid
-            assert any("identical" in e.lower() for e in errors)
+            assert any("identical" in e.lower() for e in _errors)
 
     def test_destination_nested_in_source_fails(self):
         with TemporaryDirectory() as tmpdir:
@@ -252,7 +252,7 @@ class TestPreflightValidatorDestructiveSync:
                 excludes=[],
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, _errors, warnings = validator.validate_action(action)
             assert is_valid
             assert any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
 
@@ -271,7 +271,7 @@ class TestPreflightValidatorDestructiveSync:
                 excludes=[],
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, _errors, warnings = validator.validate_action(action)
             assert is_valid
             assert not any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from dirsync.config import ConfigManager, SyncAction, SyncConfig
+from dirsync.config import ConfigManager, SyncAction
 from dirsync.validator import ConfigValidator, PreflightValidator
 
 
@@ -11,25 +11,39 @@ from dirsync.validator import ConfigValidator, PreflightValidator
 
 class TestPreflightValidatorBasicPaths:
     def test_source_equals_destination_fails(self):
-        action = SyncAction(name="test", src_path="/same/path", dst_path="/same/path")
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert not is_valid
-        assert any("identical" in e.lower() for e in errors)
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "path"
+            path.mkdir()
+            action = SyncAction(name="test", src_path=str(path), dst_path=str(path))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("identical" in e.lower() for e in errors)
 
     def test_destination_nested_in_source_fails(self):
-        action = SyncAction(name="test", src_path="/home/user", dst_path="/home/user/backup")
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert not is_valid
-        assert any("recursion" in e.lower() for e in errors)
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = src / "backup"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("recursion" in e.lower() for e in errors)
 
     def test_source_nested_in_destination_fails(self):
-        action = SyncAction(name="test", src_path="/home/user/data", dst_path="/home/user")
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert not is_valid
-        assert any("nested" in e.lower() for e in errors)
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src" / "data"
+            dst = Path(tmpdir) / "src"
+            src.parent.mkdir(parents=True)
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("nested" in e.lower() for e in errors)
 
     def test_missing_source_fails(self):
         action = SyncAction(name="test", src_path="", dst_path="/dest")
@@ -44,6 +58,17 @@ class TestPreflightValidatorBasicPaths:
         is_valid, errors, warnings = validator.validate_action(action)
         assert not is_valid
         assert any("destination" in e.lower() and "missing" in e.lower() for e in errors)
+
+    def test_nonexistent_source_fails(self):
+        with TemporaryDirectory() as tmpdir:
+            nonexistent = Path(tmpdir) / "nonexistent"
+            dst = Path(tmpdir) / "dst"
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(nonexistent), dst_path=str(dst))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("not exist" in e.lower() or "source" in e.lower() for e in errors)
 
     def test_valid_paths_pass(self):
         with TemporaryDirectory() as tmpdir:
@@ -63,92 +88,126 @@ class TestPreflightValidatorBasicPaths:
 
 class TestPreflightValidatorCron:
     def test_valid_cron_passes(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="0 2 * * *"
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid
-        assert errors == []
-
-    def test_invalid_cron_fails(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="invalid cron"
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert not is_valid
-        assert any("cron" in e.lower() and "invalid" in e.lower() for e in errors)
-
-    def test_cron_out_of_range_fails(self):
-        # Minute 99 is invalid (0-59)
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="99 * * * *"
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert not is_valid
-
-    def test_special_cron_expressions_pass(self):
-        for special in ["@yearly", "@monthly", "@weekly", "@daily", "@hourly"]:
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
             action = SyncAction(
                 name="test",
-                src_path="/src",
-                dst_path="/dst",
+                src_path=str(src),
+                dst_path=str(dst),
                 action_type="scheduled",
-                schedule=special
+                schedule="0 2 * * *"
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
-            assert is_valid, "Failed for {}".format(special)
+            assert is_valid
+            assert errors == []
+
+    def test_invalid_cron_fails(self):
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                action_type="scheduled",
+                schedule="invalid cron"
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("cron" in e.lower() and "invalid" in e.lower() for e in errors)
+
+    def test_cron_out_of_range_fails(self):
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                action_type="scheduled",
+                schedule="99 * * * *"
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+
+    def test_special_cron_expressions_pass(self):
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            for special in ["@yearly", "@monthly", "@weekly", "@daily", "@hourly"]:
+                action = SyncAction(
+                    name="test",
+                    src_path=str(src),
+                    dst_path=str(dst),
+                    action_type="scheduled",
+                    schedule=special
+                )
+                validator = PreflightValidator()
+                is_valid, errors, warnings = validator.validate_action(action)
+                assert is_valid, "Failed for {}".format(special)
 
     def test_cron_with_steps_passes(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="*/15 * * * *"  # Every 15 minutes
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                action_type="scheduled",
+                schedule="*/15 * * * *"  # Every 15 minutes
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
 
     def test_cron_with_ranges_passes(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="0 9-17 * * 1-5"  # Business hours, weekdays
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                action_type="scheduled",
+                schedule="0 9-17 * * 1-5"  # Business hours, weekdays
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
 
     def test_cron_with_lists_passes(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            action_type="scheduled",
-            schedule="0 9,12,17 * * *"  # 9am, noon, 5pm
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                action_type="scheduled",
+                schedule="0 9,12,17 * * *"  # 9am, noon, 5pm
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
 
 
 # --- PreflightValidator: Destructive Sync Warnings ---
@@ -190,24 +249,42 @@ class TestPreflightValidatorDestructiveSync:
 
 class TestConfigValidator:
     def test_duplicate_action_names_fail(self):
-        actions = [
-            SyncAction(name="dup", src_path="/src1", dst_path="/dst1"),
-            SyncAction(name="dup", src_path="/src2", dst_path="/dst2"),
-        ]
-        validator = ConfigValidator()
-        is_valid, errors, warnings = validator.validate_config(actions)
-        assert not is_valid
-        assert any("duplicate" in e.lower() for e in errors)
+        with TemporaryDirectory() as tmpdir:
+            src1 = Path(tmpdir) / "src1"
+            dst1 = Path(tmpdir) / "dst1"
+            src1.mkdir()
+            dst1.mkdir()
+            src2 = Path(tmpdir) / "src2"
+            dst2 = Path(tmpdir) / "dst2"
+            src2.mkdir()
+            dst2.mkdir()
+            actions = [
+                SyncAction(name="dup", src_path=str(src1), dst_path=str(dst1)),
+                SyncAction(name="dup", src_path=str(src2), dst_path=str(dst2)),
+            ]
+            validator = ConfigValidator()
+            is_valid, errors, warnings = validator.validate_config(actions)
+            assert not is_valid
+            assert any("duplicate" in e.lower() for e in errors)
 
     def test_unique_action_names_pass(self):
-        actions = [
-            SyncAction(name="action1", src_path="/src1", dst_path="/dst1"),
-            SyncAction(name="action2", src_path="/src2", dst_path="/dst2"),
-        ]
-        validator = ConfigValidator()
-        is_valid, errors, warnings = validator.validate_config(actions)
-        assert is_valid
-        assert errors == []
+        with TemporaryDirectory() as tmpdir:
+            src1 = Path(tmpdir) / "src1"
+            dst1 = Path(tmpdir) / "dst1"
+            src1.mkdir()
+            dst1.mkdir()
+            src2 = Path(tmpdir) / "src2"
+            dst2 = Path(tmpdir) / "dst2"
+            src2.mkdir()
+            dst2.mkdir()
+            actions = [
+                SyncAction(name="action1", src_path=str(src1), dst_path=str(dst1)),
+                SyncAction(name="action2", src_path=str(src2), dst_path=str(dst2)),
+            ]
+            validator = ConfigValidator()
+            is_valid, errors, warnings = validator.validate_config(actions)
+            assert is_valid
+            assert errors == []
 
 
 # --- ConfigManager Integration ---
@@ -219,9 +296,12 @@ class TestConfigManagerValidation:
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
         
-        # Add invalid action (same src/dst)
-        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
-        manager.config.actions.append(invalid_action)
+        # Add invalid action (same src/dst in temp dir)
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "path"
+            path.mkdir()
+            invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
+            manager.config.actions.append(invalid_action)
         
         with pytest.raises(ValueError, match="validation failed"):
             manager.save()
@@ -231,9 +311,12 @@ class TestConfigManagerValidation:
         manager = ConfigManager(path=config_path, skip_validation=True)
         manager.config.actions = []
         
-        # Add invalid action
-        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
-        manager.config.actions.append(invalid_action)
+        # Add invalid action in temp dir
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "path"
+            path.mkdir()
+            invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
+            manager.config.actions.append(invalid_action)
         
         # Should not raise
         manager.save()
@@ -244,7 +327,11 @@ class TestConfigManagerValidation:
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
         
-        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
+        # Add invalid action in temp dir
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "path"
+            path.mkdir()
+            invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
         
         with pytest.raises(ValueError, match="validation failed"):
             manager.add_action(invalid_action)
@@ -258,8 +345,6 @@ class TestConfigManagerValidation:
         assert len(manager.config.actions) == 1
         action = manager.config.actions[0]
         assert action.name == "documents-backup"
-        # Default should use Documents folder, not entire home
-        assert "Documents" in action.src_path
         # Destination should be under dir-sync-backups subfolder
         assert "dir-sync-backups" in action.dst_path
         # Validate the default passes validation
@@ -271,9 +356,14 @@ class TestConfigManagerValidation:
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
         
-        # Add valid action
-        action = SyncAction(name="test", src_path="/src", dst_path="/dst")
-        manager.config.actions.append(action)
+        # Add valid action in temp dir
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
+            manager.config.actions.append(action)
         
         is_valid, errors, warnings = manager.validate()
         assert is_valid
@@ -285,12 +375,20 @@ class TestConfigManagerValidation:
 
 class TestSyncActionValidateMethod:
     def test_validate_method_exists(self):
-        action = SyncAction(name="test", src_path="/src", dst_path="/dst")
-        is_valid, errors, warnings = action.validate()
-        assert is_valid
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
+            is_valid, errors, warnings = action.validate()
+            assert is_valid
 
     def test_validate_method_catches_errors(self):
-        action = SyncAction(name="test", src_path="/same", dst_path="/same")
-        is_valid, errors, warnings = action.validate()
-        assert not is_valid
-        assert len(errors) > 0
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "path"
+            path.mkdir()
+            action = SyncAction(name="test", src_path=str(path), dst_path=str(path))
+            is_valid, errors, warnings = action.validate()
+            assert not is_valid
+            assert len(errors) > 0

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -466,7 +466,7 @@ class TestConfigManagerValidation:
         config_path = tmp_path / "config.yml"
         fake_home = tmp_path / "home"
         fake_home.mkdir()
-        docs_path = fake_home / "Documents"
+        fallback_src = fake_home / "dir-sync-source"
         import dirsync.config as config_module
 
         monkeypatch.setattr(config_module.Path, "home", lambda: fake_home)
@@ -478,7 +478,8 @@ class TestConfigManagerValidation:
         action = manager.config.actions[0]
         assert action.name == "documents-backup"
         assert "dir-sync-backups" in action.dst_path
-        assert action.src_path == str(docs_path)
+        assert action.src_path == str(fallback_src)
+        assert not (fake_home / "Documents").exists()
         is_valid, errors, _warnings = action.validate()
         assert is_valid, "Default action failed validation: {}".format(errors)
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -97,7 +97,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="0 2 * * *"
+                schedule="0 2 * * *",
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -115,7 +115,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="invalid cron"
+                schedule="invalid cron",
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -133,7 +133,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="99 * * * *"
+                schedule="99 * * * *",
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -151,7 +151,7 @@ class TestPreflightValidatorCron:
                     src_path=str(src),
                     dst_path=str(dst),
                     action_type="scheduled",
-                    schedule=special
+                    schedule=special,
                 )
                 validator = PreflightValidator()
                 is_valid, errors, warnings = validator.validate_action(action)
@@ -168,7 +168,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="*/15 * * * *"  # Every 15 minutes
+                schedule="*/15 * * * *",  # Every 15 minutes
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -185,7 +185,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="0 9-17 * * 1-5"  # Business hours, weekdays
+                schedule="0 9-17 * * 1-5",  # Business hours, weekdays
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -202,7 +202,7 @@ class TestPreflightValidatorCron:
                 src_path=str(src),
                 dst_path=str(dst),
                 action_type="scheduled",
-                schedule="0 9,12,17 * * *"  # 9am, noon, 5pm
+                schedule="0 9,12,17 * * *",  # 9am, noon, 5pm
             )
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -339,6 +339,104 @@ class TestConfigManagerValidation:
 
             with pytest.raises(ValueError, match="validation failed"):
                 manager.add_action(invalid_action)
+
+    def test_add_action_rolls_back_on_configuration_validation_failure(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            valid_src = base / "valid-src"
+            valid_dst = base / "valid-dst"
+            valid_src.mkdir()
+            valid_dst.mkdir()
+            existing_action = SyncAction(
+                name="existing", src_path=str(valid_src), dst_path=str(valid_dst)
+            )
+
+            broken_src = base / "broken-src"
+            broken_dst = broken_src / "nested"
+            broken_src.mkdir()
+            broken_dst.mkdir()
+            invalid_existing = SyncAction(
+                name="broken", src_path=str(broken_src), dst_path=str(broken_dst)
+            )
+
+            new_src = base / "new-src"
+            new_dst = base / "new-dst"
+            new_src.mkdir()
+            new_dst.mkdir()
+            new_action = SyncAction(name="new", src_path=str(new_src), dst_path=str(new_dst))
+
+            manager.config.actions = [existing_action, invalid_existing]
+
+            with pytest.raises(ValueError, match="Configuration validation failed"):
+                manager.add_action(new_action)
+
+            assert manager.config.find_action("existing") is not None
+            assert manager.config.find_action("new") is None
+
+    def test_update_action_rolls_back_on_configuration_validation_failure(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            src = base / "src"
+            dst = base / "dst"
+            src.mkdir()
+            dst.mkdir()
+            current_action = SyncAction(name="edit", src_path=str(src), dst_path=str(dst))
+
+            broken_src = base / "broken-src"
+            broken_dst = broken_src / "nested"
+            broken_src.mkdir()
+            broken_dst.mkdir()
+            invalid_existing = SyncAction(
+                name="broken", src_path=str(broken_src), dst_path=str(broken_dst)
+            )
+
+            replacement_dst = base / "replacement-dst"
+            replacement_dst.mkdir()
+            updated_action = SyncAction(
+                name="edit", src_path=str(src), dst_path=str(replacement_dst)
+            )
+
+            manager.config.actions = [current_action, invalid_existing]
+
+            with pytest.raises(ValueError, match="Configuration validation failed"):
+                manager.update_action(updated_action)
+
+            action = manager.config.find_action("edit")
+            assert action is not None
+            assert action.src_path == str(src)
+            assert action.dst_path == str(dst)
+
+    def test_remove_action_rolls_back_on_configuration_validation_failure(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            src1 = base / "src1"
+            dst1 = base / "dst1"
+            src1.mkdir()
+            dst1.mkdir()
+            src2 = base / "src2"
+            dst2 = src2 / "nested"
+            src2.mkdir()
+            dst2.mkdir()
+
+            valid_action = SyncAction(name="valid", src_path=str(src1), dst_path=str(dst1))
+            invalid_action = SyncAction(name="invalid", src_path=str(src2), dst_path=str(dst2))
+
+            manager.config.actions = [valid_action, invalid_action]
+
+            with pytest.raises(ValueError, match="Configuration validation failed"):
+                manager.remove_action("valid")
+
+            assert manager.config.find_action("valid") is not None
+            assert manager.config.find_action("invalid") is not None
 
     def test_ensure_default_creates_safe_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "config.yml"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -38,7 +38,6 @@ class TestPreflightValidatorBasicPaths:
             dst = Path(tmpdir) / "src"
             src.parent.mkdir(parents=True)
             src.mkdir()
-            dst.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             validator = PreflightValidator()
             is_valid, errors, warnings = validator.validate_action(action)
@@ -215,33 +214,42 @@ class TestPreflightValidatorCron:
 
 class TestPreflightValidatorDestructiveSync:
     def test_one_way_no_filters_warns(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            method="one_way",
-            includes=[],
-            excludes=[]
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid  # Still valid
-        assert any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                method="one_way",
+                includes=[],
+                excludes=[],
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
+            assert any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
 
     def test_one_way_with_filters_no_warning(self):
-        action = SyncAction(
-            name="test",
-            src_path="/src",
-            dst_path="/dst",
-            method="one_way",
-            includes=["*.txt"],
-            excludes=[]
-        )
-        validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
-        assert is_valid
-        # Should not have destructive warning when filters are present
-        assert not any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(
+                name="test",
+                src_path=str(src),
+                dst_path=str(dst),
+                method="one_way",
+                includes=["*.txt"],
+                excludes=[],
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
+            assert not any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
 
 
 # --- ConfigValidator: Cross-Action Validation ---
@@ -336,18 +344,23 @@ class TestConfigManagerValidation:
         with pytest.raises(ValueError, match="validation failed"):
             manager.add_action(invalid_action)
 
-    def test_ensure_default_creates_safe_config(self, tmp_path):
+    def test_ensure_default_creates_safe_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "config.yml"
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        docs_path = fake_home / "Documents"
+        import dirsync.config as config_module
+
+        monkeypatch.setattr(config_module.Path, "home", lambda: fake_home)
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
         manager.ensure_default()
-        
+
         assert len(manager.config.actions) == 1
         action = manager.config.actions[0]
         assert action.name == "documents-backup"
-        # Destination should be under dir-sync-backups subfolder
         assert "dir-sync-backups" in action.dst_path
-        # Validate the default passes validation
+        assert action.src_path == str(docs_path)
         is_valid, errors, warnings = action.validate()
         assert is_valid, "Default action failed validation: {}".format(errors)
 
@@ -355,8 +368,7 @@ class TestConfigManagerValidation:
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
-        
-        # Add valid action in temp dir
+
         with TemporaryDirectory() as tmpdir:
             src = Path(tmpdir) / "src"
             dst = Path(tmpdir) / "dst"
@@ -364,10 +376,10 @@ class TestConfigManagerValidation:
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             manager.config.actions.append(action)
-        
-        is_valid, errors, warnings = manager.validate()
-        assert is_valid
-        assert errors == []
+
+            is_valid, errors, warnings = manager.validate()
+            assert is_valid
+            assert errors == []
 
 
 # --- SyncAction.validate() method ---

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -303,30 +303,27 @@ class TestConfigManagerValidation:
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
-        
-        # Add invalid action (same src/dst in temp dir)
+
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "path"
             path.mkdir()
             invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
             manager.config.actions.append(invalid_action)
-        
-        with pytest.raises(ValueError, match="validation failed"):
-            manager.save()
+
+            with pytest.raises(ValueError, match="validation failed"):
+                manager.save()
 
     def test_save_with_validation_disabled(self, tmp_path):
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path, skip_validation=True)
         manager.config.actions = []
-        
-        # Add invalid action in temp dir
+
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "path"
             path.mkdir()
             invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
             manager.config.actions.append(invalid_action)
-        
-        # Should not raise
+
         manager.save()
         assert config_path.exists()
 
@@ -334,15 +331,14 @@ class TestConfigManagerValidation:
         config_path = tmp_path / "config.yml"
         manager = ConfigManager(path=config_path)
         manager.config.actions = []
-        
-        # Add invalid action in temp dir
+
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "path"
             path.mkdir()
             invalid_action = SyncAction(name="bad", src_path=str(path), dst_path=str(path))
-        
-        with pytest.raises(ValueError, match="validation failed"):
-            manager.add_action(invalid_action)
+
+            with pytest.raises(ValueError, match="validation failed"):
+                manager.add_action(invalid_action)
 
     def test_ensure_default_creates_safe_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "config.yml"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,296 @@
+import pytest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from dirsync.config import ConfigManager, SyncAction, SyncConfig
+from dirsync.validator import ConfigValidator, PreflightValidator
+
+
+# --- PreflightValidator: Basic Path Validation ---
+
+
+class TestPreflightValidatorBasicPaths:
+    def test_source_equals_destination_fails(self):
+        action = SyncAction(name="test", src_path="/same/path", dst_path="/same/path")
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("identical" in e.lower() for e in errors)
+
+    def test_destination_nested_in_source_fails(self):
+        action = SyncAction(name="test", src_path="/home/user", dst_path="/home/user/backup")
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("recursion" in e.lower() for e in errors)
+
+    def test_source_nested_in_destination_fails(self):
+        action = SyncAction(name="test", src_path="/home/user/data", dst_path="/home/user")
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("nested" in e.lower() for e in errors)
+
+    def test_missing_source_fails(self):
+        action = SyncAction(name="test", src_path="", dst_path="/dest")
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("source" in e.lower() and "missing" in e.lower() for e in errors)
+
+    def test_missing_destination_fails(self):
+        action = SyncAction(name="test", src_path="/src", dst_path="")
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("destination" in e.lower() and "missing" in e.lower() for e in errors)
+
+    def test_valid_paths_pass(self):
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst = Path(tmpdir) / "dst"
+            src.mkdir()
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid
+            assert errors == []
+
+
+# --- PreflightValidator: Cron Validation ---
+
+
+class TestPreflightValidatorCron:
+    def test_valid_cron_passes(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="0 2 * * *"
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid
+        assert errors == []
+
+    def test_invalid_cron_fails(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="invalid cron"
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+        assert any("cron" in e.lower() and "invalid" in e.lower() for e in errors)
+
+    def test_cron_out_of_range_fails(self):
+        # Minute 99 is invalid (0-59)
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="99 * * * *"
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert not is_valid
+
+    def test_special_cron_expressions_pass(self):
+        for special in ["@yearly", "@monthly", "@weekly", "@daily", "@hourly"]:
+            action = SyncAction(
+                name="test",
+                src_path="/src",
+                dst_path="/dst",
+                action_type="scheduled",
+                schedule=special
+            )
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert is_valid, "Failed for {}".format(special)
+
+    def test_cron_with_steps_passes(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="*/15 * * * *"  # Every 15 minutes
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid
+
+    def test_cron_with_ranges_passes(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="0 9-17 * * 1-5"  # Business hours, weekdays
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid
+
+    def test_cron_with_lists_passes(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            action_type="scheduled",
+            schedule="0 9,12,17 * * *"  # 9am, noon, 5pm
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid
+
+
+# --- PreflightValidator: Destructive Sync Warnings ---
+
+
+class TestPreflightValidatorDestructiveSync:
+    def test_one_way_no_filters_warns(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            method="one_way",
+            includes=[],
+            excludes=[]
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid  # Still valid
+        assert any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
+
+    def test_one_way_with_filters_no_warning(self):
+        action = SyncAction(
+            name="test",
+            src_path="/src",
+            dst_path="/dst",
+            method="one_way",
+            includes=["*.txt"],
+            excludes=[]
+        )
+        validator = PreflightValidator()
+        is_valid, errors, warnings = validator.validate_action(action)
+        assert is_valid
+        # Should not have destructive warning when filters are present
+        assert not any("destructive" in w.lower() or "overwrite" in w.lower() for w in warnings)
+
+
+# --- ConfigValidator: Cross-Action Validation ---
+
+
+class TestConfigValidator:
+    def test_duplicate_action_names_fail(self):
+        actions = [
+            SyncAction(name="dup", src_path="/src1", dst_path="/dst1"),
+            SyncAction(name="dup", src_path="/src2", dst_path="/dst2"),
+        ]
+        validator = ConfigValidator()
+        is_valid, errors, warnings = validator.validate_config(actions)
+        assert not is_valid
+        assert any("duplicate" in e.lower() for e in errors)
+
+    def test_unique_action_names_pass(self):
+        actions = [
+            SyncAction(name="action1", src_path="/src1", dst_path="/dst1"),
+            SyncAction(name="action2", src_path="/src2", dst_path="/dst2"),
+        ]
+        validator = ConfigValidator()
+        is_valid, errors, warnings = validator.validate_config(actions)
+        assert is_valid
+        assert errors == []
+
+
+# --- ConfigManager Integration ---
+
+
+class TestConfigManagerValidation:
+    def test_save_validates_by_default(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        
+        # Add invalid action (same src/dst)
+        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
+        manager.config.actions.append(invalid_action)
+        
+        with pytest.raises(ValueError, match="validation failed"):
+            manager.save()
+
+    def test_save_with_validation_disabled(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path, skip_validation=True)
+        manager.config.actions = []
+        
+        # Add invalid action
+        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
+        manager.config.actions.append(invalid_action)
+        
+        # Should not raise
+        manager.save()
+        assert config_path.exists()
+
+    def test_add_action_validates(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        
+        invalid_action = SyncAction(name="bad", src_path="/same", dst_path="/same")
+        
+        with pytest.raises(ValueError, match="validation failed"):
+            manager.add_action(invalid_action)
+
+    def test_ensure_default_creates_safe_config(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        manager.ensure_default()
+        
+        assert len(manager.config.actions) == 1
+        action = manager.config.actions[0]
+        assert action.name == "documents-backup"
+        # Default should use Documents folder, not entire home
+        assert "Documents" in action.src_path
+        # Destination should be under dir-sync-backups subfolder
+        assert "dir-sync-backups" in action.dst_path
+        # Validate the default passes validation
+        is_valid, errors, warnings = action.validate()
+        assert is_valid, "Default action failed validation: {}".format(errors)
+
+    def test_validate_method(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        manager = ConfigManager(path=config_path)
+        manager.config.actions = []
+        
+        # Add valid action
+        action = SyncAction(name="test", src_path="/src", dst_path="/dst")
+        manager.config.actions.append(action)
+        
+        is_valid, errors, warnings = manager.validate()
+        assert is_valid
+        assert errors == []
+
+
+# --- SyncAction.validate() method ---
+
+
+class TestSyncActionValidateMethod:
+    def test_validate_method_exists(self):
+        action = SyncAction(name="test", src_path="/src", dst_path="/dst")
+        is_valid, errors, warnings = action.validate()
+        assert is_valid
+
+    def test_validate_method_catches_errors(self):
+        action = SyncAction(name="test", src_path="/same", dst_path="/same")
+        is_valid, errors, warnings = action.validate()
+        assert not is_valid
+        assert len(errors) > 0

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -212,7 +212,7 @@ class TestPreflightValidatorCron:
                 schedule="0 9-17 * * 1-5",  # Business hours, weekdays
             )
             validator = PreflightValidator()
-            is_valid, _errors, warnings = validator.validate_action(action)
+            is_valid, _errors, _warnings = validator.validate_action(action)
             assert is_valid
 
     def test_cron_with_lists_passes(self):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -69,6 +69,30 @@ class TestPreflightValidatorBasicPaths:
             assert not is_valid
             assert any("not exist" in e.lower() or "source" in e.lower() for e in errors)
 
+    def test_source_file_fails(self):
+        with TemporaryDirectory() as tmpdir:
+            src_file = Path(tmpdir) / "source.txt"
+            dst = Path(tmpdir) / "dst"
+            src_file.write_text("data", encoding="utf-8")
+            dst.mkdir()
+            action = SyncAction(name="test", src_path=str(src_file), dst_path=str(dst))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("source path must be a directory" in e.lower() for e in errors)
+
+    def test_existing_destination_file_fails(self):
+        with TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "src"
+            dst_file = Path(tmpdir) / "dest.txt"
+            src.mkdir()
+            dst_file.write_text("data", encoding="utf-8")
+            action = SyncAction(name="test", src_path=str(src), dst_path=str(dst_file))
+            validator = PreflightValidator()
+            is_valid, errors, warnings = validator.validate_action(action)
+            assert not is_valid
+            assert any("destination path must be a directory" in e.lower() for e in errors)
+
     def test_valid_paths_pass(self):
         with TemporaryDirectory() as tmpdir:
             src = Path(tmpdir) / "src"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -16,7 +16,7 @@ class TestPreflightValidatorBasicPaths:
             path.mkdir()
             action = SyncAction(name="test", src_path=str(path), dst_path=str(path))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("identical" in e.lower() for e in errors)
 
@@ -28,7 +28,7 @@ class TestPreflightValidatorBasicPaths:
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("recursion" in e.lower() for e in errors)
 
@@ -40,21 +40,21 @@ class TestPreflightValidatorBasicPaths:
             src.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("nested" in e.lower() for e in errors)
 
     def test_missing_source_fails(self):
         action = SyncAction(name="test", src_path="", dst_path="/dest")
         validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
+        is_valid, errors, _warnings = validator.validate_action(action)
         assert not is_valid
         assert any("source" in e.lower() and "missing" in e.lower() for e in errors)
 
     def test_missing_destination_fails(self):
         action = SyncAction(name="test", src_path="/src", dst_path="")
         validator = PreflightValidator()
-        is_valid, errors, warnings = validator.validate_action(action)
+        is_valid, errors, _warnings = validator.validate_action(action)
         assert not is_valid
         assert any("destination" in e.lower() and "missing" in e.lower() for e in errors)
 
@@ -65,7 +65,7 @@ class TestPreflightValidatorBasicPaths:
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(nonexistent), dst_path=str(dst))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("not exist" in e.lower() or "source" in e.lower() for e in errors)
 
@@ -77,7 +77,7 @@ class TestPreflightValidatorBasicPaths:
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(src_file), dst_path=str(dst))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("source path must be a directory" in e.lower() for e in errors)
 
@@ -89,7 +89,7 @@ class TestPreflightValidatorBasicPaths:
             dst_file.write_text("data", encoding="utf-8")
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst_file))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("destination path must be a directory" in e.lower() for e in errors)
 
@@ -101,7 +101,7 @@ class TestPreflightValidatorBasicPaths:
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert is_valid
             assert errors == []
 
@@ -124,7 +124,7 @@ class TestPreflightValidatorCron:
                 schedule="0 2 * * *",
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert is_valid
             assert errors == []
 
@@ -142,7 +142,7 @@ class TestPreflightValidatorCron:
                 schedule="invalid cron",
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert not is_valid
             assert any("cron" in e.lower() and "invalid" in e.lower() for e in errors)
 
@@ -160,7 +160,7 @@ class TestPreflightValidatorCron:
                 schedule="99 * * * *",
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, _errors, _warnings = validator.validate_action(action)
             assert not is_valid
 
     def test_special_cron_expressions_pass(self):
@@ -178,7 +178,7 @@ class TestPreflightValidatorCron:
                     schedule=special,
                 )
                 validator = PreflightValidator()
-                is_valid, errors, warnings = validator.validate_action(action)
+                is_valid, _errors, _warnings = validator.validate_action(action)
                 assert is_valid, "Failed for {}".format(special)
 
     def test_cron_with_steps_passes(self):
@@ -195,7 +195,7 @@ class TestPreflightValidatorCron:
                 schedule="*/15 * * * *",  # Every 15 minutes
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, _errors, _warnings = validator.validate_action(action)
             assert is_valid
 
     def test_cron_with_ranges_passes(self):
@@ -212,7 +212,7 @@ class TestPreflightValidatorCron:
                 schedule="0 9-17 * * 1-5",  # Business hours, weekdays
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, _errors, warnings = validator.validate_action(action)
             assert is_valid
 
     def test_cron_with_lists_passes(self):
@@ -229,7 +229,7 @@ class TestPreflightValidatorCron:
                 schedule="0 9,12,17 * * *",  # 9am, noon, 5pm
             )
             validator = PreflightValidator()
-            is_valid, errors, warnings = validator.validate_action(action)
+            is_valid, errors, _warnings = validator.validate_action(action)
             assert is_valid
 
 
@@ -295,7 +295,7 @@ class TestConfigValidator:
                 SyncAction(name="dup", src_path=str(src2), dst_path=str(dst2)),
             ]
             validator = ConfigValidator()
-            is_valid, errors, warnings = validator.validate_config(actions)
+            is_valid, errors, _warnings = validator.validate_config(actions)
             assert not is_valid
             assert any("duplicate" in e.lower() for e in errors)
 
@@ -314,7 +314,7 @@ class TestConfigValidator:
                 SyncAction(name="action2", src_path=str(src2), dst_path=str(dst2)),
             ]
             validator = ConfigValidator()
-            is_valid, errors, warnings = validator.validate_config(actions)
+            is_valid, errors, _warnings = validator.validate_config(actions)
             assert is_valid
             assert errors == []
 
@@ -479,7 +479,7 @@ class TestConfigManagerValidation:
         assert action.name == "documents-backup"
         assert "dir-sync-backups" in action.dst_path
         assert action.src_path == str(docs_path)
-        is_valid, errors, warnings = action.validate()
+        is_valid, errors, _warnings = action.validate()
         assert is_valid, "Default action failed validation: {}".format(errors)
 
     def test_validate_method(self, tmp_path):
@@ -495,7 +495,7 @@ class TestConfigManagerValidation:
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
             manager.config.actions.append(action)
 
-            is_valid, errors, warnings = manager.validate()
+            is_valid, errors, _warnings = manager.validate()
             assert is_valid
             assert errors == []
 
@@ -511,7 +511,7 @@ class TestSyncActionValidateMethod:
             src.mkdir()
             dst.mkdir()
             action = SyncAction(name="test", src_path=str(src), dst_path=str(dst))
-            is_valid, errors, warnings = action.validate()
+            is_valid, _errors, _warnings = action.validate()
             assert is_valid
 
     def test_validate_method_catches_errors(self):
@@ -519,6 +519,6 @@ class TestSyncActionValidateMethod:
             path = Path(tmpdir) / "path"
             path.mkdir()
             action = SyncAction(name="test", src_path=str(path), dst_path=str(path))
-            is_valid, errors, warnings = action.validate()
+            is_valid, errors, _warnings = action.validate()
             assert not is_valid
             assert len(errors) > 0

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,10 +1,10 @@
-import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from dirsync.config import ConfigManager, SyncAction
 from dirsync.validator import ConfigValidator, PreflightValidator
-
 
 # --- PreflightValidator: Basic Path Validation ---
 


### PR DESCRIPTION
- Add PreflightValidator class to validate sync actions before save or execution
- Add ConfigValidator for cross-action validation such as duplicate action names
- Validate: source=dest, nested paths, missing or non-existent source paths, and invalid cron expressions
- Warn on dangerous destinations and destructive sync configurations
- Integrate validation into ConfigManager save/add/update/import flows
- Fix ensure_default to use a safe sample source instead of the entire home directory
- Add validator and config regression coverage for the new guardrails

Follow-up work for backend availability checks and platform-specific automation constraints remains outside this PR scope.

Implements part of issue #7 (DS-003): preflight validation guardrails for invalid or destructive setups