### PR TITLE
ci: add pr-gate.yml; remove pull_request from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  pull_request:
   push:
     branches: [main, master, "release/*"]
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -2,9 +2,6 @@ name: PR Gate
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
 
 concurrency:
   group: pr-gate-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,18 @@
+name: PR Gate
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate:
+    uses: nikolareljin/ci-helpers/.github/workflows/pr-gate.yml@production
+    with:
+      python_version: "3.11"
+      working_directory: "."


### PR DESCRIPTION
## Summary

- **`ci.yml`**: removed the `pull_request` trigger so full CI runs only on post-merge pushes to `main`/`master`/`release/*`
- **`pr-gate.yml`**: added a lightweight PR gate using `pr-gate.yml@production` for pull requests with concurrency cancellation
- The PR gate workflow is intentionally always created for pull requests so it remains usable as a required check

## Before -> After

| | Before | After |
|---|---|---|
| CI trigger on PR push | `ci.yml` full scan | `pr-gate.yml` lightweight gate |
| Required PR check | Full CI path | Always-created PR gate path |
| Duplicate runs | Possible | Superseded PR gate runs cancelled |

## Test plan

- [ ] Open a code PR -> `pr-gate` runs, `ci` does not
- [ ] Open a docs-only PR -> `pr-gate` is still created, `ci` does not run
- [ ] Merge to `main` -> `ci` runs